### PR TITLE
Add RDFa tags to breadcrumbs

### DIFF
--- a/templates/components/common/breadcrumbs.html
+++ b/templates/components/common/breadcrumbs.html
@@ -1,11 +1,12 @@
-<ul class="breadcrumbs">
+<ul class="breadcrumbs" vocab="http://schema.org/" typeof="BreadcrumbList">
     {{#each breadcrumbs}}
-        <li class="breadcrumb {{#if @last}}is-active{{/if}}">
+        <li property="itemListElement" typeof="ListItem" class="breadcrumb {{#if @last}}is-active{{/if}}">
             {{#if url}}
-                <a href="{{url}}" class="breadcrumb-label">{{name}}</a>
+                <a property="item" typeof="WebPage" href="{{url}}" class="breadcrumb-label"><span property="name">{{name}}</span></a>
             {{else}}
-                <span class="breadcrumb-label">{{name}}</span>
+                <span property="name" class="breadcrumb-label">{{name}}</span>
             {{/if}}
+            <meta property="position" content="{{add @index 1}}">
         </li>
     {{/each}}
 </ul>


### PR DESCRIPTION
#### What?

Add the RDFa BreadcrumbList markup to the generated breadcrumbs to help Google (and other web crawlers) understand the shop categories better.

#### Documentation

Follows the schema.org [breadcrumb markup guidelines](http://schema.org/BreadcrumbList), and passes Google's [structured data testing tool](https://search.google.com/structured-data/testing-tool). Both appear to suggest using OL instead of UL for the list element, but it validates as is and sticking with UL seems preferable to avoid potential css issues.

#### Screenshots

Google's testing tool before the markup - no breadcrumbs detected:
<img width="1333" alt="screenshot 2017-07-14 14 01 10" src="https://user-images.githubusercontent.com/4799852/28213225-1436d1ea-689d-11e7-9a9d-b530f5bd4e33.png">

Same page after the markup - breadcrumbs now found:
<img width="1393" alt="screenshot 2017-07-14 14 01 24" src="https://user-images.githubusercontent.com/4799852/28213226-143b6886-689d-11e7-909f-14a9a620740f.png">


